### PR TITLE
feat: Redesign all sample pages

### DIFF
--- a/src/components/rokaf-mcrc-advanced-v2/MapView.tsx
+++ b/src/components/rokaf-mcrc-advanced-v2/MapView.tsx
@@ -5,12 +5,11 @@ import { Track, GroundThreat, TrackStatus, ThreatStatus } from './types';
 interface MapViewProps {
   tracks: Track[];
   groundThreats: GroundThreat[];
-  selectedTrack: Track | null;
   onSelectTrack: (track: Track) => void;
   showTrails: boolean;
 }
 
-const MapView: React.FC<MapViewProps> = ({ tracks, groundThreats, selectedTrack, onSelectTrack, showTrails }) => {
+const MapView: React.FC<MapViewProps> = ({ tracks, groundThreats, onSelectTrack, showTrails }) => {
   const renderTrack = (track: Track) => {
     const colors: Record<TrackStatus, string> = {
       'FRIENDLY': 'text-green-400 bg-green-900/30 border-green-400',

--- a/src/components/rokaf-mcrc-ai-system/StateProvider.tsx
+++ b/src/components/rokaf-mcrc-ai-system/StateProvider.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useReducer, useContext, Dispatch } from 'react';
-import { Track } from './types';
+import { Track, GridSector, AISystem, AIAlert } from './types';
 import { activeTracks, gridSectors, aiSystems, aiAlerts } from './constants';
 
 interface State {
@@ -12,9 +12,9 @@ interface State {
   autoResponse: boolean;
   aiAnalyzing: boolean;
   activeTracks: Track[];
-  gridSectors: any[];
-  aiSystems: any;
-  aiAlerts: any[];
+  gridSectors: GridSector[];
+  aiSystems: { [key: string]: AISystem };
+  aiAlerts: AIAlert[];
 }
 
 type Action =

--- a/src/components/rokaf-radar-controller-workstation/ControlPanel.tsx
+++ b/src/components/rokaf-radar-controller-workstation/ControlPanel.tsx
@@ -7,10 +7,6 @@ interface ControlPanelProps {
   onRadarModeChange: (mode: string) => void;
   radarRange: number;
   onRadarRangeChange: (range: number) => void;
-  signalFilter: string;
-  onSignalFilterChange: (filter: string) => void;
-  trackingMode: string;
-  onTrackingModeChange: (mode: string) => void;
   radarSystems: RadarSystem[];
   radarPerformance: RadarPerformance;
 }
@@ -18,7 +14,6 @@ interface ControlPanelProps {
 const ControlPanel: React.FC<ControlPanelProps> = (props) => {
   const {
     radarMode, onRadarModeChange, radarRange, onRadarRangeChange,
-    signalFilter, onSignalFilterChange, trackingMode, onTrackingModeChange,
     radarSystems, radarPerformance
   } = props;
 

--- a/src/components/rokaf-radar-controller-workstation/TrackDetails.tsx
+++ b/src/components/rokaf-radar-controller-workstation/TrackDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Target, Zap } from 'lucide-react';
+import { Target } from 'lucide-react';
 import { RadarTrack } from './types';
 
 interface TrackDetailsProps {

--- a/src/samples/rokaf-mcrc-advanced-v2.tsx
+++ b/src/samples/rokaf-mcrc-advanced-v2.tsx
@@ -39,7 +39,6 @@ const ROKAFMCRCAdvancedCore = () => {
           <MapView
             tracks={state.tracks}
             groundThreats={state.groundThreats}
-            selectedTrack={state.selectedTrack}
             onSelectTrack={(track: Track) => dispatch({ type: 'SET_SELECTED_TRACK', payload: track })}
             showTrails={state.showTrails}
           />


### PR DESCRIPTION
Refactor all sample page components into a modern, component-based architecture.

For each page, create smaller, more manageable components for each part of the UI.

Introduce a `StateProvider` using React Context to centralize state management for each page.

Modernize the UI with a cleaner layout and a consistent dark theme.

Separate types and constants into their own files for better organization.